### PR TITLE
Updates to the local dev instructions

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -14,11 +14,11 @@ snap install dotrun
 ```
 
 You can then run the site by simply typing within the repository:
-```
+``` bash
 dotrun
 ```
 
-Then to learn about this script's options, type:
+Then to learn about this snap's options, type:
 
 ``` bash
 dotrun --help

--- a/HACKING.md
+++ b/HACKING.md
@@ -16,6 +16,7 @@ You can then run the site by simply typing within the repository:
 ``` bash
 dotrun
 ```
+After this, go to http://0.0.0.0:8003/admin because http://0.0.0.0:8003/ itself will just redirect to canonical.com/partners.
 
 Then to learn about this snap's options, type:
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -2,25 +2,35 @@
 
 The partners.ubuntu.com codebase is a [Django](https://www.djangoproject.com/) app, which also includes some [NPM](https://www.npmjs.com/)-based tools and tasks for building static files like CSS.
 
-## Running the site with Docker
+## Running the site with Dotrun
 
-The recommended way to run the site is with the existing `./run` script, which uses Docker behind the scenes.
+The recommended way to run the site is by using the dotrun snap.
 
 First [install Docker](https://docs.docker.com/engine/installation/) and add your user to the `docker` group.
+Secondly, install dotrun
+```
+snap refresh
+snap install dotrun
+```
+
+You can then run the site by simply typing within the repository:
+```
+dotrun
+```
 
 Then to learn about this script's options, type:
 
 ``` bash
-./run --help
+dotrun --help
 ```
 
 The basic options are:
 
 ``` bash
-./run start  # Start the Django server, optionally watching for changes
-./run build  # Build the CSS
-./run watch  # Watch and build the CSS whenever Sass changes
-./run clean  # Remove created files and docker containers
+dorun start  # Start the Django server, optionally watching for changes
+dorun build  # Build the CSS
+dorun watch  # Watch and build the CSS whenever Sass changes
+dorun clean  # Remove created files and docker containers
 ```
 
 ### Watching in the background
@@ -28,10 +38,10 @@ The basic options are:
 The `start` function optionally takes a `--watch` argument:
 
 ``` bash
-./run start --watch
+dotrun start --watch
 ```
 
-This will effectively run the `./run watch` command in the background while also running the server.
+This will effectively run the `dotrun watch` command in the background while also running the server.
 
 **NB:** You won't see the output from the watcher by default. This makes it difficult to know if it's working properly.
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -9,7 +9,6 @@ The recommended way to run the site is by using the dotrun snap.
 First [install Docker](https://docs.docker.com/engine/installation/) and add your user to the `docker` group.
 Secondly, install dotrun
 ```
-snap refresh
 snap install dotrun
 ```
 


### PR DESCRIPTION
## Done

- I've updated the readme to show how to run the site using dotrun.

## QA

1. Download this branch
2. Follow the HACKING.md to run the site with dotrun
3. Go to http://0.0.0.0:8003/
4. Confirm site is running normally locally.
## Issue / Card

Fixes #285 
